### PR TITLE
remove "Z" from local time timestamp

### DIFF
--- a/src/sdmon.c
+++ b/src/sdmon.c
@@ -167,7 +167,7 @@ int main(int argc, const char *argv[]) {
   printf("{\n");
   printf("\"version\": \"%s\",\n", VERSION);
 
-  printf("\"date\": \"%d-%02d-%02dT%02d:%02d:%02d.000Z\",\n", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+  printf("\"date\": \"%d-%02d-%02dT%02d:%02d:%02d.000\",\n", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
 
   // this is more or less static...
   // "MMC_IOC_CMD": "c048b300", => 0xc048b300


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/ISO_8601 the letter "Z" at the end of the a timestamp would indicate that it's in UTC. But the function localtime() gets the time in the local time zone.